### PR TITLE
Fix ErrorException

### DIFF
--- a/reportwidgets/ClearCache.php
+++ b/reportwidgets/ClearCache.php
@@ -58,7 +58,9 @@ class ClearCache extends ReportWidgetBase
     }
 
     private function get_dir_size($directory) {
-        if(count(scandir($directory)) == 2)    return 0;
+        if(!file_exists($directory) || count(scandir($directory)) <= 2) {
+            return 0;
+        }
         $size = 0;
         foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($directory)) as $file) {
             $size += $file->getSize();


### PR DESCRIPTION
When `/storage/cms/` or `/storage/twig/` folder doesn't exists it throws ErrorException:

```
exception 'ErrorException' with message 'scandir(/usr/local/www/data/website.cz/www/storage/cms/cache): failed to open dir: No such file or directory’
```

at

```
/plugins/romanov/clearcachewidget/reportwidgets/ClearCache.php:61
```

This PR fix it.
